### PR TITLE
WolfoQualityofLife: Depend on newer WolfoFixes

### DIFF
--- a/mod-WolfoQoL_Main/manifest.json
+++ b/mod-WolfoQoL_Main/manifest.json
@@ -4,7 +4,7 @@
     "website_url": "https://github.com/WolfoIsBestWolf/ror2-WolfoQualityoLlife",
     "description": "[Client-Side]: Adds colored effects to Mercenary Skins and Blight Acrid, Unique ping icons for everything, Reminders to do stuff, Informational chat messages (death, losing items), expanded Death Screen, and like a lot of things.",
     "dependencies": [
-		"Wolfo-WolfFixes-1.0.0",
+		"Wolfo-WolfFixes-1.2.3",
         "Rune580-Risk_Of_Options-2.8.2",
 		"RiskofThunder-R2API_Networking-1.0.4",
 		"RiskofThunder-R2API_Prefab-1.1.1",


### PR DESCRIPTION
This avoids pulling the meta R2API mod that pulls ~30 R2API submodules keeping the mod list clean.