### PR TITLE
Add config for Mithrix Phase 2 name fix

### DIFF
--- a/proj_WolfoQoL_Client/code/Text/TextChanges.cs
+++ b/proj_WolfoQoL_Client/code/Text/TextChanges.cs
@@ -242,7 +242,7 @@ namespace WolfoQoL_Client.Text
         private static void MithrixPhase2OverrideLunarChimeraHordeName(On.EntityStates.Missions.BrotherEncounter.Phase2.orig_OnEnter orig, EntityStates.Missions.BrotherEncounter.Phase2 self)
         {
             orig(self);
-            if (self.phaseBossGroup)
+            if (WConfig.cfgMithrixPhase2TextFix.Value && self.phaseBossGroup)
             {
                 BossGroup boss = self.phaseBossGroup.GetComponent<BossGroup>();
                 boss.lastDisplayedPriority = 0;

--- a/proj_WolfoQoL_Client/code/WConfig_Client.cs
+++ b/proj_WolfoQoL_Client/code/WConfig_Client.cs
@@ -67,6 +67,7 @@ namespace WolfoQoL_Client
         public static ConfigEntry<bool> cfgDarkTwisted;
         public static ConfigEntry<bool> cfgTwistedFire;
         public static ConfigEntry<bool> cfgTwistedSound;
+        public static ConfigEntry<bool> cfgMithrixPhase2TextFix;
         public static ConfigEntry<bool> cfgMithrixPhase4SkipFix;
 
         public static ConfigEntry<bool> cfgSmoothCaptain;
@@ -745,6 +746,12 @@ namespace WolfoQoL_Client
                 "Lunar Chimera / Larva name change",
                 true,
                 "Adds Lunar Chimera type to Chimera names\n\nRenames Larva to Acid Larva due to their internal name."
+            );
+            cfgMithrixPhase2TextFix = ConfigFile_Client.Bind(
+                "Text",
+                "Mithrix Phase 2 Boss Name",
+                true,
+                "Fixes the boss name in phase 2 to properly say Lunar Chimera."
             );
             cfgTextOther = ConfigFile_Client.Bind(
                 "Text",


### PR DESCRIPTION
The use of mods that change the Mithix fight (namely [Umbral](https://thunderstore.io/package/Nuxlar/UmbralMithrix/)) do not interact well with this fix, a config option has been added.

Feel free to change text/var names on merge, I tried to put it in a decent place in the config file